### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ Suppose we wanted to download Emily Bronte's "Wuthering Heights." We could find 
 
 
 ```r
+
 library(dplyr)
+library(magrittr)
 library(gutenbergr)
+
+gutenberg_works() %>% 
+  filter(title == "Wuthering Heights")
 
 gutenberg_works() %>%
   filter(title == "Wuthering Heights")


### PR DESCRIPTION
Included library(magrittr) for the pipe operator. If the existing code
```
library(dplyr)
library(gutenbergr)

gutenberg_works() %>%
  filter(title == "Wuthering Heights")
```

is executed without the inclusion of library(magrittr), then it returns the error, `Error: could not find function "%>%"`

Thus, I propose the inclusion of library(magrittr) in the above code.